### PR TITLE
attempt to fix mac os clipboard issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "format": "prettier --write \"**/*.{js,jsx,md,json,css,prettierrc,eslintrc,html}\""
+    "format": "prettier --write \"**/*.{js,jsx,md,json,css,prettierrc,eslintrc,html}\"",
+    "postinstall": "node scripts/set-permissions.js"
   },
   "keywords": [
     "clipboard",

--- a/scripts/set-permissions.js
+++ b/scripts/set-permissions.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { exec } = require('child_process');
+const { join } = require('path');
+
+// ensure that osx-copy-image is executable
+if (process.platform === 'darwin') exec(`chmod +x "${join(__dirname, 'osx-copy-image')}"`);


### PR DESCRIPTION
fixes #1 
- added postinstall hook that runs node script which `chmod +x`s osx cp bin

**Warning:** did not test on mac os, just ensured that the post install hook works